### PR TITLE
feat: add polling to savemanager-service

### DIFF
--- a/src/modules/draw/draw-directive.js
+++ b/src/modules/draw/draw-directive.js
@@ -276,7 +276,8 @@ angular.module('anol.draw')
                             } else {
                                 const feat = evt.selected[0];
                                 if (scope.removeActive) {
-                                    if (scope.setState) {
+                                    // only mark existing features as removed
+                                    if (scope.setState && feat.getId() !== undefined) {
                                         feat.set('_digitizeState', DigitizeState.REMOVED);
                                     } else {
                                         layer.getSource().removeFeature(feat);

--- a/src/modules/savemanager/savemanager-service.js
+++ b/src/modules/savemanager/savemanager-service.js
@@ -262,7 +262,7 @@ angular.module('anol.savemanager')
             /**
              * Get features with given state.
              * @param {string} layerName The layer to get the features from.
-             * @param {DigitizeState} state The digitizeState to filter by.
+             * @param {DigitizeState[keyof DigitizeState]} state The digitizeState to filter by.
              * @returns The list of features.
              */
             SaveManager.prototype.getFeatures = function(layerName, state) {
@@ -487,13 +487,9 @@ angular.module('anol.savemanager')
                 }
 
                 // changed if pollingitem has entry that is not in current features
-                return pollingResult.some(pollingItem => {
-                    var feat = features.find(f => f.getId() === pollingItem.id);
-                    if (!feat) {
-                        return true;
-                    }
-                    return false;
-                });
+                return pollingResult.some(pollingItem =>
+                    features.find(f => f.getId() === pollingItem.id) === undefined
+                );
             };
 
             /**

--- a/src/modules/savemanager/savemanager-service.js
+++ b/src/modules/savemanager/savemanager-service.js
@@ -39,34 +39,35 @@ angular.module('anol.savemanager')
                 }
                 this.changeListenerKeys = [];
 
+                const createDigitizeStateHandler = (feature) => {
+                    return () => {
+                        switch(feature.get('_digitizeState')) {
+                            case DigitizeState.NEW:
+                                addHandler(feature);
+                                break;
+                            case DigitizeState.CHANGED:
+                                changeHandler(feature);
+                                break;
+                            case DigitizeState.REMOVED:
+                                removeHandler(feature);
+                                break;
+                            default:
+                                break;
+                        }
+                    };
+                }
+
                 this.addListenerKey = this.source.on('addfeature', e => {
                     const feature = e.feature;
-                    if (angular.isDefined(addHandler)) {
-                        addHandler(feature);
-                    }
-                    if (angular.isDefined(changeHandler)) {
-                        this.changeListenerKeys.push(feature.on('change:_digitizeState', () => {
-                            if (feature.get('_digitizeState') === DigitizeState.CHANGED) {
-                                changeHandler(feature);
-                            }
-                        }));
-                    }
+                    const digitizeStateHandler = createDigitizeStateHandler(feature);
+                    const listenerKey = feature.on('change:_digitizeState', digitizeStateHandler);
+                    this.changeListenerKeys.push(listenerKey);
                 });
 
-                this.removeListenerKey = this.source.on('removefeature', e => {
-                    if (angular.isDefined(removeHandler)) {
-                        removeHandler(e.feature);
-                    }
-                });
-
-                if (angular.isDefined(changeHandler)) {
-                    for (const feature of this.source.getFeatures()) {
-                        this.changeListenerKeys.push(feature.on('change:_digitizeState', () => {
-                            if (feature.get('_digitizeState') === DigitizeState.CHANGED) {
-                                changeHandler(feature);
-                            }
-                        }));
-                    }
+                for (const feature of this.source.getFeatures()) {
+                    const digitizeStateHandler = createDigitizeStateHandler(feature);
+                    const listenerKey = feature.on('change:_digitizeState', digitizeStateHandler);
+                    this.changeListenerKeys.push(listenerKey);
                 }
             }
 
@@ -90,6 +91,8 @@ angular.module('anol.savemanager')
         var _saveNewFeaturesUrl;
         var _saveChangedFeaturesUrl;
         var _saveRemovedFeaturesUrl;
+        var _pollingUrl;
+        var _pollingInterval;
         var _saveableLayers = [];
         /**
          * @ngdoc method
@@ -109,6 +112,14 @@ angular.module('anol.savemanager')
             _saveRemovedFeaturesUrl = saveUrl;
         };
 
+        this.setPollingUrl = function(pollingUrl) {
+          _pollingUrl = pollingUrl;
+        }
+
+        this.setPollingInterval = function(pollingInterval) {
+          _pollingInterval = pollingInterval;
+        }
+
         LayersServiceProvider.registerAddLayerHandler(function(layer) {
             if(layer.saveable !== true) {
                 return;
@@ -120,7 +131,7 @@ angular.module('anol.savemanager')
             }
         });
 
-        this.$get = ['$rootScope', '$q', '$http', '$timeout', '$translate', function($rootScope, $q, $http, $timeout, $translate) {
+        this.$get = ['$rootScope', '$q', '$http', '$timeout', '$interval', '$translate', function($rootScope, $q, $http, $timeout, $interval, $translate) {
             /**
              * @ngdoc service
              * @name anol.savemanager.SaveManagerService
@@ -128,15 +139,16 @@ angular.module('anol.savemanager')
              * @description
              * Collects changes in saveable layers and send them to given saveUrl
              */
-            var SaveManager = function(saveNewFeaturesUrl, saveChangedFeaturesUrl, saveRemovedFeaturesUrl, saveableLayers) {
+            var SaveManager = function(saveNewFeaturesUrl, saveChangedFeaturesUrl, saveRemovedFeaturesUrl, pollingUrl, pollingInterval, saveableLayers) {
                 var self = this;
                 this.saveNewFeaturesUrl = saveNewFeaturesUrl;
                 this.saveChangedFeaturesUrl = saveChangedFeaturesUrl;
                 this.saveRemovedFeaturesUrl = saveRemovedFeaturesUrl;
+                this.pollingUrl = pollingUrl;
+                this.pollingInterval = pollingInterval;
+                this.activePollingIntervals = {};
+                this.lastPollingResults = {};
                 this.changedLayers = {};
-                this.addedFeatures = {};
-                this.changedFeatures = {};
-                this.removedFeatures = {};
 
                 angular.forEach(saveableLayers, function(layer) {
                     self.addLayer(layer);
@@ -180,9 +192,7 @@ angular.module('anol.savemanager')
              * handler for ol3 feature added event
              */
             SaveManager.prototype.featureAddedHandler = function(feature, layer) {
-                var self = this;
-                self.addNewFeature(feature, layer);
-                self.updatedLayerChanged(layer);
+                this.updateLayerChanged(layer);
             };
             /**
              * private function
@@ -190,9 +200,7 @@ angular.module('anol.savemanager')
              * handler for ol3 feature changed event
              */
             SaveManager.prototype.featureChangedHandler = function(feature, layer) {
-                var self = this;
-                self.addChangedFeature(feature, layer);
-                self.updatedLayerChanged(layer);
+                this.updateLayerChanged(layer);
             };
             /**
              * private function
@@ -200,9 +208,7 @@ angular.module('anol.savemanager')
              * handler for ol3 feature removed event
              */
             SaveManager.prototype.featureRemovedHandler = function(feature, layer) {
-                var self = this;
-                self.addRemovedFeature(feature, layer);
-                self.updatedLayerChanged(layer);
+                this.updateLayerChanged(layer);
             };
             /**
              * private function
@@ -221,102 +227,27 @@ angular.module('anol.savemanager')
                 }
             };
 
-            SaveManager.prototype.updatedLayerChanged = function(layer) {
-                // TODO check if we also the the $rootScope.$apply handling as in addChangedLayer()
-                var changed = false;
-                if (this.isDefinedAndPopulated(this.addedFeatures, layer)) {
-                    changed = true;
-                }
-                if (this.isDefinedAndPopulated(this.changedFeatures, layer)) {
-                    changed = true;
-                }
-                if (this.isDefinedAndPopulated(this.removedFeatures, layer)) {
-                    changed = true;
-                }
+            /**
+             * Update layerChanged state of given layer.
+             * @param {anol.layer.Feature} layer
+             */
+            SaveManager.prototype.updateLayerChanged = function(layer) {
+                const possibleStates = [DigitizeState.NEW, DigitizeState.CHANGED, DigitizeState.REMOVED];
+                const changed = layer.getFeatures().some(feat => possibleStates.includes(feat.get('_digitizeState')));
 
                 if (changed && !(layer.name in this.changedLayers)) {
-                    this.changedLayers[layer.name] = layer;
+                    this.changedLayers = {
+                      ...this.changedLayers,
+                      [layer.name]: layer
+                    }
                 }
                 else if (!changed && layer.name in this.changedLayers) {
-                    delete this.changedLayers[layer.name];
+                    const {
+                      [layer.name]: _,
+                      ...changedLayers
+                    } = this.changedLayers;
+                    this.changedLayers = {...changedLayers};
                 }
-            };
-
-            SaveManager.prototype.isDefinedAndPopulated = function (layersMap, layer) {
-                return layer.name in layersMap && layersMap[layer.name].length > 0;
-            };
-
-            SaveManager.prototype.addNewFeature = function(feature, layer) {
-              if (!(layer.name in this.addedFeatures)) {
-                  this.addedFeatures[layer.name] = [];
-              }
-              this.addedFeatures[layer.name].push(feature);
-              this.updatedLayerChanged(layer);
-            };
-
-            SaveManager.prototype.addChangedFeature = function(feature, layer) {
-              // ignore added features
-              if (this.isInAddedFeatures(feature, layer.name)) {
-                  return;
-              }
-              if (!(layer.name in this.changedFeatures)) {
-                  this.changedFeatures[layer.name] = [];
-              }
-              if (this.changedFeatures[layer.name].includes(feature)) {
-                  return;
-              }
-              this.changedFeatures[layer.name].push(feature);
-              this.updatedLayerChanged(layer);
-            };
-
-            SaveManager.prototype.addRemovedFeature = function(feature, layer) {
-              // ignore added features
-              if (this.isInAddedFeatures(feature, layer.name)) {
-                  var featureIdx = this.addedFeatures[layer.name].indexOf(feature);
-                  this.addedFeatures[layer.name].splice(featureIdx, 1);
-                  return;
-              }
-              // remove from changedfeatures
-              if (this.isInChangedFeatures(feature, layer.name)) {
-                  var featureIdx = this.changedFeatures[layer.name].indexOf(feature);
-                  this.changedFeatures[layer.name].splice(featureIdx, 1);
-              }
-              if (!(layer.name in this.removedFeatures)) {
-                  this.removedFeatures[layer.name] = [];
-              }
-              if (this.removedFeatures[layer.name].includes(feature)) {
-                  return;
-              }
-              this.removedFeatures[layer.name].push(feature);
-              this.updatedLayerChanged(layer);
-            };
-
-            /**
-             * Checks if a feature is an added feature.
-             *
-             * @param {ol.Feature} feature The feature to check.
-             * @param {String} layerName The name of the layer to which the feature belongs.
-             * @returns {boolean} True, if feature is in addedFeatures. False otherwise.
-             */
-            SaveManager.prototype.isInAddedFeatures = function(feature, layerName) {
-              if (!(layerName in this.addedFeatures)) {
-                  return false;
-              }
-              return this.addedFeatures[layerName].includes(feature);
-            };
-
-            /**
-             * Checks if a feature is a changed feature.
-             *
-             * @param {ol.Feature} feature The feature to check.
-             * @param {String} layerName The name of the layer to which the feature belongs.
-             * @returns {boolean} True, if feature is in changedFeatures. False otherwise.
-             */
-            SaveManager.prototype.isInChangedFeatures = function(feature, layerName) {
-              if (!(layerName in this.changedFeatures)) {
-                  return false;
-              }
-              return this.changedFeatures[layerName].includes(feature);
             };
 
             /**
@@ -326,9 +257,47 @@ angular.module('anol.savemanager')
              */
             SaveManager.prototype.changesDone = function(layerName) {
                 delete this.changedLayers[layerName];
-                delete this.addedFeatures[layerName];
-                delete this.changedFeatures[layerName];
-                delete this.removedFeatures[layerName];
+            };
+
+            /**
+             * Get features with given state.
+             * @param {string} layerName The layer to get the features from.
+             * @param {DigitizeState} state The digitizeState to filter by.
+             * @returns The list of features.
+             */
+            SaveManager.prototype.getFeatures = function(layerName, state) {
+              const layer = this.changedLayers[layerName];
+              if (!layer) {
+                return [];
+              }
+              return layer.getFeatures().filter(f => f.get('_digitizeState') === state);
+            }
+
+            /**
+             * Get features that were added to layer.
+             * @param {anol.layer.Feature} layerName The layer to get the features from.
+             * @returns The list of features.
+             */
+            SaveManager.prototype.getAddedFeatures = function(layerName) {
+              return this.getFeatures(layerName, DigitizeState.NEW);
+            };
+
+            /**
+             * Get features that were changed on layer.
+             * @param {anol.layer.Feature} layerName The layer to get the features from.
+             * @returns The list of features.
+             */
+            SaveManager.prototype.getChangedFeatures = function(layerName) {
+              return this.getFeatures(layerName, DigitizeState.CHANGED);
+            };
+
+            /**
+             * Get features that were removed from layer.
+             * @param {anol.layer.Feature} layerName The layer to get the features from.
+             * @returns The list of features.
+             */
+            SaveManager.prototype.getRemovedFeatures = function(layerName) {
+              return this.getFeatures(layerName, DigitizeState.REMOVED);
             };
 
             /**
@@ -355,42 +324,40 @@ angular.module('anol.savemanager')
                             properties: _omit(featureObject.properties, '_digitizeState')
                         };
                     };
-                    if (self.isDefinedAndPopulated(self.addedFeatures, layer)) {
+                    const addedFeatures = this.getAddedFeatures(layer.name);
+                    if (addedFeatures.length > 0) {
                         var data = {
                             name: layer.name,
                             featureCollection: {
                                 type: 'FeatureCollection',
-                                features: self.addedFeatures[layer.name].map(writeFeature)
+                                features: addedFeatures.map(writeFeature)
                             }
                         };
-                        var promise = $http.post(self.saveNewFeaturesUrl, data);
+                        var promise = $http.post(this.saveNewFeaturesUrl, data);
                         promises.push(promise);
                     }
-                    if (self.isDefinedAndPopulated(self.changedFeatures, layer)) {
+                    const changedFeatures = this.getChangedFeatures(layer.name);
+                    if (changedFeatures.length > 0) {
                         var data = {
                             name: layer.name,
                             featureCollection: {
                                 type: 'FeatureCollection',
-                                features: self.changedFeatures[layer.name].map(writeFeature)
+                                features: changedFeatures.map(writeFeature)
                             }
                         };
-                        var promise = $http.put(self.saveChangedFeaturesUrl, data);
+                        var promise = $http.put(this.saveChangedFeaturesUrl, data);
                         promises.push(promise);
                     }
-                    if (self.isDefinedAndPopulated(self.removedFeatures, layer)) {
-                        var ids = [];
-                        angular.forEach(self.removedFeatures[layer.name], function(feature) {
-                          var id = feature.getId();
-                          if (!id) {
-                            return;
-                          }
-                          ids.push(id);
-                        });
+                    const removedFeatures = this.getRemovedFeatures(layer.name);
+                    if (removedFeatures.length > 0) {
                         var data = {
                             name: layer.name,
-                            ids: ids
-                        };
-                        var promise = $http.post(self.saveRemovedFeaturesUrl, data);
+                            featureCollection: {
+                                type: 'FeatureCollection',
+                                features: removedFeatures.map(writeFeature)
+                            }
+                        }
+                        var promise = $http.post(this.saveRemovedFeaturesUrl, data);
                         promises.push(promise);
                     }
                     $q.all(promises).then(function(responses) {
@@ -398,7 +365,10 @@ angular.module('anol.savemanager')
                         self.changesDone(layer.name);
                         var responses_data = [];
                         angular.forEach(responses, function(response) {
-                          responses_data.push(response.data);
+                          responses_data.push({
+                            status: response.status,
+                            data: response.data
+                          });
                         });
                         deferred.resolve(responses_data);
                     }, function (response) {
@@ -429,11 +399,199 @@ angular.module('anol.savemanager')
                 return $q.all(promises);
             };
 
+            /**
+             * Check if layer has changes.
+             * @param {string} layerName The name of the layer to check.
+             * @returns True, if layer has changes. False, otherwise.
+             */
             SaveManager.prototype.hasChanges = function (layerName) {
                 return layerName in this.changedLayers;
             }
 
-            _saveManagerInstance = new SaveManager(_saveNewFeaturesUrl, _saveChangedFeaturesUrl, _saveRemovedFeaturesUrl, _saveableLayers);
+            /**
+             * Start polling for changes in backend.
+             * @param {string} layerName Name of the layer to poll.
+             * @param {Function} success_cb Callback when polling succeeded.
+             * @param {Function} error_cb Callback when polling failed.
+             * @returns
+             */
+            SaveManager.prototype.startPolling = function(layerName, success_cb, error_cb) {
+                if (this.activePollingIntervals[layerName]) {
+                    console.log(`Cannot start polling. Polling for layer ${layerName} already started.`);
+                    return;
+                }
+                var self = this;
+                this.activePollingIntervals[layerName] = $interval(function() {
+                    var url = self.pollingUrl + '?layer=' + layerName;
+                    $http.get(url).then(function(resp) {
+                        self.lastPollingResults[layerName] = resp.data;
+                        success_cb(resp.data, resp.status);
+                    }, function(resp) {
+                        error_cb(resp.data, resp.status)
+                    });
+                }, this.pollingInterval);
+            };
+
+            /**
+             * Stop polling for changes in backend.
+             * @param {string} layerName Name of the layer to stop polling for.
+             * @returns
+             */
+            SaveManager.prototype.stopPolling = function(layerName) {
+                var interval = this.activePollingIntervals[layerName];
+                if (!interval) {
+                    console.log(`Cannot stop polling. Polling for layer ${layerName} not started.`);
+                    return;
+                }
+                $interval.cancel(interval);
+                this.activePollingIntervals[layerName] = undefined;
+            };
+
+            /**
+             * Check if polling contains changes for the given layer.
+             * @param {anol.layer.Feature} layer The layer to check for.
+             * @returns True, if polling contains changes. False, otherwise.
+             */
+            SaveManager.prototype.hasPollingChanges = function(layer) {
+                if (!layer) {
+                    return false;
+                }
+                var layerName = layer.name;
+                var pollingResult = this.lastPollingResults[layerName];
+                if (!pollingResult) {
+                    return false;
+                }
+
+                var features = layer.getFeatures();
+                // changed if matching polling feature has newer timestamp
+                // changed if feat has id and no matching polling feature
+                var hasChanges = features
+                    .filter(f => [DigitizeState.CHANGED, DigitizeState.REMOVED].includes(f.get('_digitizeState')))
+                    .some(feat => {
+                        var pollingItem = pollingResult.find(item => item.id === feat.getId());
+                        if (pollingItem) {
+                            var pollingModified = new Date(pollingItem.modified);
+                            var featureModified = new Date(feat.get('modified'));
+                            // feature was modified on remote
+                            if (pollingModified > featureModified) {
+                                return true;
+                            }
+                            return false;
+                        }
+                        // feature was deleted on remote
+                        return true;
+                    });
+
+                if (hasChanges) {
+                    return true;
+                }
+
+                // changed if pollingitem has entry that is not in current features
+                return pollingResult.some(pollingItem => {
+                    var feat = features.find(f => f.getId() === pollingItem.id);
+                    if (!feat) {
+                        return true;
+                    }
+                    return false;
+                });
+            };
+
+            /**
+             * Refresh the given layer based on the polling results.
+             *
+             * All features will be called from backend. Added features will be kept.
+             * Changed features will only be kept, if they were not modified in backend.
+             * Deleted features will only be kept, if they were not modified in backend.
+             *
+             * @param {anol.layer.Feature} layer The layer to refresh.
+             * @param {ol.Feature[]} addedFeatures List of added features.
+             * @param {ol.Feature[]} changedFeatures List of changed features.
+             * @param {olFeature[]} removedFeatures List of removed features.
+             * @returns
+             */
+            SaveManager.prototype.refreshLayerByPollingResult = function (layer, addedFeatures, changedFeatures, removedFeatures) {
+                if (!layer) {
+                    return;
+                }
+                var layerName = layer.name;
+                var pollingResult = this.lastPollingResults[layerName];
+                if (!pollingResult) {
+                    return;
+                }
+
+                // filter features that have no conflicts,
+                // i.e. that were not changed/deleted on remote
+                var filterNoConflicts = function(feat) {
+                    var pollingItem = pollingResult.find(function(item) {
+                        return feat.getId() === item.id;
+                    });
+                    // remote deleted
+                    if (!pollingItem) {
+                        return false;
+                    }
+                    var featureModified = new Date(feat.get('modified'));
+                    var pollingModified = new Date(pollingItem.modified);
+                    // remote changed
+                    if (pollingModified > featureModified) {
+                        return false;
+                    }
+                    return true;
+                };
+
+                changedFeatures
+                    .filter(filterNoConflicts)
+                    .forEach(feat => {
+                        const layerFeature = layer.getFeatures().find(f => f.getId() === feat.getId());
+                        layerFeature.setProperties(feat.getProperties());
+                    });
+
+                removedFeatures
+                    .filter(filterNoConflicts)
+                    .forEach(feat => {
+                        const layerFeature = layer.getFeatures().find(f => f.getId() === feat.getId());
+                        layerFeature.setProperties(feat.getProperties());
+                    });
+
+                // add addedFeatures to layer
+                layer.addFeatures(addedFeatures);
+                this.updateLayerChanged(layer);
+            };
+
+            /**
+             * Refresh given layer based on polling results.
+             * @param {anol.layer.Feature} layer The layer to refresh.
+             * @returns
+             */
+            SaveManager.prototype.refreshLayer = function(layer) {
+                var self = this;
+                if (!layer) {
+                    return;
+                }
+                var layerName = layer.name;
+                // keep references of edited features before refreshing layer
+                var addedFeatures = this.getAddedFeatures(layerName);
+                var changedFeatures = this.getChangedFeatures(layerName);
+                var removedFeatures = this.getRemovedFeatures(layerName);
+                var unregister = $rootScope.$watch(function() {
+                    return layer.loaded;
+                }, function(loaded) {
+                    if(loaded === true) {
+                        // we only want to watch until loaded is true once
+                        unregister();
+                        self.refreshLayerByPollingResult(layer, addedFeatures, changedFeatures, removedFeatures);
+                    }
+                });
+                layer.refresh();
+            };
+
+            _saveManagerInstance = new SaveManager(
+                _saveNewFeaturesUrl,
+                _saveChangedFeaturesUrl,
+                _saveRemovedFeaturesUrl,
+                _pollingUrl,
+                _pollingInterval,
+                _saveableLayers
+            );
             return _saveManagerInstance;
         }];
     }]);


### PR DESCRIPTION
This adds polling functionality to the savemanager.

When refreshing a layer, we check for conflicting features (i.e. features that were edited by others and the current user). Those features will be reset. Other features will be kept.